### PR TITLE
Exclude FuseStaking contract from tvl

### DIFF
--- a/projects/gooddollar/abi.json
+++ b/projects/gooddollar/abi.json
@@ -11,18 +11,5 @@
 		],
 		"stateMutability": "view",
 		"type": "function"
-	},
-	"totalDelegated": {
-		"type": "function",
-		"stateMutability": "view",
-		"outputs": [
-			{
-				"type": "uint256",
-				"name": "",
-				"internalType": "uint256"
-			}
-		],
-		"name": "totalDelegated",
-		"inputs": []
 	}
 }

--- a/projects/gooddollar/abi.json
+++ b/projects/gooddollar/abi.json
@@ -11,5 +11,18 @@
 		],
 		"stateMutability": "view",
 		"type": "function"
+	},
+	"totalDelegated": {
+		"type": "function",
+		"stateMutability": "view",
+		"outputs": [
+			{
+				"type": "uint256",
+				"name": "",
+				"internalType": "uint256"
+			}
+		],
+		"name": "totalDelegated",
+		"inputs": []
 	}
-}
+} 

--- a/projects/gooddollar/index.js
+++ b/projects/gooddollar/index.js
@@ -1,7 +1,6 @@
 const sdk = require("@defillama/sdk");
 const abi = require('./abi.json');
 const BigNumber = require("bignumber.js");
-const { sumTokens } = require("../helper/unwrapLPs");
 
 const tokens = {
     aUSDC: "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -12,31 +11,16 @@ const tokens = {
 };
 
 const FUSE_STAKING = '0xA199F0C353E25AdF022378B0c208D600f39a6505';
-const GOV_STAKING = '0xFAF457Fb4A978Be059506F6CD41f9B30fCa753b0';
+const GOVERNANCE_STAKING = '0xFAF457Fb4A978Be059506F6CD41f9B30fCa753b0';
 const RESERVE_ADDRESS = '0x6C35677206ae7FF1bf753877649cF57cC30D1c42';
-const AAVE_STAKING_V2 = '0xF4c34BED7Dd779485692bB1857aCf9c561B45010';
-const COMPOUND_STAKING = '0xD33bA17C8A644C585089145e86E282fada6F3bfd';
-const COMPOUND_STAKING_V2 = '0x02416eb83CFf1f19163F21010149C3867f3261e1';
 const COMMUNITY_SAFE = '0x5Eb5f5fE13d1D5e6440DbD5913412299Bc5B5564';
 const GOODDOLLAR_DECIMALS = 2;
-
-async function eth(timestamp, ethBlock) {
-    const balances = {};
-    await sumTokens(balances, [
-        [tokens.aUSDC, AAVE_STAKING_V2],
-        [tokens.cDAI, COMPOUND_STAKING],
-        [tokens.cDAI, COMPOUND_STAKING_V2],
-        [tokens.cDAI, RESERVE_ADDRESS]
-    ], ethBlock)
-
-    return balances;
-};
 
 async function fuseStaking(timestamp, ethBlock, chainBlocks) {    
     const gdStaked = (await sdk.api.erc20.balanceOf({
         target: tokens.Gfuse,
         chain: 'fuse',
-        owner: GOV_STAKING,
+        owner: GOVERNANCE_STAKING,
         block: chainBlocks['fuse'],
     })).output;
 
@@ -83,30 +67,16 @@ async function convertGoodDollarsToDai(gdAmount, ethBlock) {
     return await new BigNumber(gdPriceInDAI).times(gdAmount).div(10 ** GOODDOLLAR_DECIMALS);
 }
 
-async function fuse(timestamp, ethBlock, chainBlocks) {
-    const fuseAmount = (await sdk.api.abi.call({
-        abi: abi.totalDelegated,
-        chain: 'fuse',
-        target: FUSE_STAKING,
-        block: chainBlocks['fuse']
-    })).output;
-
-    const balances = {};
-    await sdk.util.sumSingleBalance(balances, tokens.FUSE, Number(fuseAmount));
-
-    return balances;
-}
-
 module.exports = {
-    methodology: `Aggregation of funds staked in our contracts on Ethereum and Fuse, funds locked in reserve backing G$ token and community treasury. G$ value was converted to USD based on current price at the reserve.`,
+    methodology: `Staking accounts for G$ balance of our governance staking contract. Treasury accounts for G$ balances of our community treasury safe & fuse staking contract. The majority of staked funds are in PoS contracts and don't count as tvl at the moment.`,
     misrepresentedTokens: true,
     timetravel: true,
     ethereum: {
-        tvl: eth
+        tvl: () => ({}),
     },
     fuse: {
+        tvl: () => ({}),
         staking: fuseStaking,
-        tvl: fuse,
         treasury: fuseTreasury
     },
 }

--- a/projects/gooddollar/index.js
+++ b/projects/gooddollar/index.js
@@ -1,6 +1,7 @@
 const sdk = require("@defillama/sdk");
 const abi = require('./abi.json');
 const BigNumber = require("bignumber.js");
+const { sumTokens } = require("../helper/unwrapLPs");
 
 const tokens = {
     aUSDC: "0xbcca60bb61934080951369a648fb03df4f96263c",
@@ -11,16 +12,31 @@ const tokens = {
 };
 
 const FUSE_STAKING = '0xA199F0C353E25AdF022378B0c208D600f39a6505';
-const GOVERNANCE_STAKING = '0xFAF457Fb4A978Be059506F6CD41f9B30fCa753b0';
+const GOV_STAKING = '0xFAF457Fb4A978Be059506F6CD41f9B30fCa753b0';
 const RESERVE_ADDRESS = '0x6C35677206ae7FF1bf753877649cF57cC30D1c42';
+const AAVE_STAKING_V2 = '0xF4c34BED7Dd779485692bB1857aCf9c561B45010';
+const COMPOUND_STAKING = '0xD33bA17C8A644C585089145e86E282fada6F3bfd';
+const COMPOUND_STAKING_V2 = '0x02416eb83CFf1f19163F21010149C3867f3261e1';
 const COMMUNITY_SAFE = '0x5Eb5f5fE13d1D5e6440DbD5913412299Bc5B5564';
 const GOODDOLLAR_DECIMALS = 2;
+
+async function eth(timestamp, ethBlock) {
+    const balances = {};
+    await sumTokens(balances, [
+        [tokens.aUSDC, AAVE_STAKING_V2],
+        [tokens.cDAI, COMPOUND_STAKING],
+        [tokens.cDAI, COMPOUND_STAKING_V2],
+        [tokens.cDAI, RESERVE_ADDRESS]
+    ], ethBlock)
+
+    return balances;
+};
 
 async function fuseStaking(timestamp, ethBlock, chainBlocks) {    
     const gdStaked = (await sdk.api.erc20.balanceOf({
         target: tokens.Gfuse,
         chain: 'fuse',
-        owner: GOVERNANCE_STAKING,
+        owner: GOV_STAKING,
         block: chainBlocks['fuse'],
     })).output;
 
@@ -67,16 +83,30 @@ async function convertGoodDollarsToDai(gdAmount, ethBlock) {
     return await new BigNumber(gdPriceInDAI).times(gdAmount).div(10 ** GOODDOLLAR_DECIMALS);
 }
 
+async function fuse(timestamp, ethBlock, chainBlocks) {
+    const fuseAmount = (await sdk.api.abi.call({
+        abi: abi.totalDelegated,
+        chain: 'fuse',
+        target: FUSE_STAKING,
+        block: chainBlocks['fuse']
+    })).output;
+
+    const balances = {};
+    await sdk.util.sumSingleBalance(balances, tokens.FUSE, Number(fuseAmount));
+
+    return balances;
+}
+
 module.exports = {
-    methodology: `Staking accounts for G$ balance of our governance staking contract. Treasury accounts for G$ balances of our community treasury safe & fuse staking contract. The majority of staked funds are in PoS contracts and don't count as tvl at the moment.`,
+    methodology: `Aggregation of funds staked in our contracts on Ethereum and Fuse, funds locked in reserve backing G$ token and community treasury. G$ value was converted to USD based on current price at the reserve.`,
     misrepresentedTokens: true,
     timetravel: true,
     ethereum: {
-        tvl: () => ({}),
+        tvl: eth
     },
     fuse: {
-        tvl: () => ({}),
         staking: fuseStaking,
+        tvl: () => ({}),
         treasury: fuseTreasury
     },
 }


### PR DESCRIPTION
As required in [previous PR](https://github.com/DefiLlama/DefiLlama-Adapters/pull/1652) FuseStaking PoS contract balance won't count as tvl until deposits will be tokenised and considered liquid staking 